### PR TITLE
removed idGenerator from update's method signature

### DIFF
--- a/modules/common/app/edu/berkeley/ground/lib/factory/core/EdgeFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/core/EdgeFactory.java
@@ -37,8 +37,5 @@ public interface EdgeFactory extends ItemFactory<Edge> {
   @Override
   Edge retrieveFromDatabase(Database dbSource, long id) throws GroundException;
 
-  @Override
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
-
   List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException;
 }

--- a/modules/common/app/edu/berkeley/ground/lib/factory/core/GraphFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/core/GraphFactory.java
@@ -34,9 +34,6 @@ public interface GraphFactory extends ItemFactory<Graph> {
   @Override
   Graph retrieveFromDatabase(final Database dbSource, final long id) throws GroundException;
 
-  @Override
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
-
   List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException;
 
   @Override

--- a/modules/common/app/edu/berkeley/ground/lib/factory/core/NodeFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/core/NodeFactory.java
@@ -32,8 +32,5 @@ public interface NodeFactory extends ItemFactory<Node> {
   @Override
   Node retrieveFromDatabase(Database dbSource, long id) throws GroundException;
 
-  @Override
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
-
   List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException;
 }

--- a/modules/common/app/edu/berkeley/ground/lib/factory/core/StructureFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/core/StructureFactory.java
@@ -34,9 +34,6 @@ public interface StructureFactory extends ItemFactory<Structure> {
   @Override
   Structure retrieveFromDatabase(final Database dbSource, final long id) throws GroundException;
 
-  @Override
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
-
   List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException;
 
   @Override

--- a/modules/common/app/edu/berkeley/ground/lib/factory/usage/LineageEdgeFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/usage/LineageEdgeFactory.java
@@ -36,8 +36,5 @@ public interface LineageEdgeFactory extends ItemFactory<LineageEdge> {
   @Override
   LineageEdge retrieveFromDatabase(Database dbSource, long id) throws GroundException;
 
-  @Override
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
-
   List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException;
 }

--- a/modules/common/app/edu/berkeley/ground/lib/factory/usage/LineageGraphFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/usage/LineageGraphFactory.java
@@ -36,8 +36,5 @@ public interface LineageGraphFactory extends ItemFactory<LineageGraph> {
   @Override
   LineageGraph retrieveFromDatabase(Database dbSource, long id) throws GroundException;
 
-  @Override
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
-
   List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException;
 }

--- a/modules/common/app/edu/berkeley/ground/lib/factory/version/ItemFactory.java
+++ b/modules/common/app/edu/berkeley/ground/lib/factory/version/ItemFactory.java
@@ -36,7 +36,7 @@ public interface ItemFactory<T extends Item> {
    * @param childId the new version's id
    * @param parentIds the ids of the parents of the child
    */
-  void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
   /**
    * Truncate the item to only have the most recent levels.

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/GraphDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/GraphDao.java
@@ -56,11 +56,6 @@ public class GraphDao extends ItemDao<Graph> implements GraphFactory {
   }
 
   @Override
-  public void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    super.update(idGenerator, itemId, childId, parentIds);
-  }
-
-  @Override
   public List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException {
     Graph graph  = retrieveFromDatabase(dbSource, sourceKey);
     return super.getLeaves(dbSource, graph.getId());

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/ItemDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/ItemDao.java
@@ -83,7 +83,7 @@ public class ItemDao<T extends Item> implements ItemFactory<T> {
    * @param parentIds the ids of the parents of the child
    */
   @Override
-  public void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException {
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundException {
     // If a parent is specified, great. If it's not specified, then make it a child of EMPTY.
     if (parentIds.isEmpty()) {
       parentIds.add(0L);

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/LineageEdgeDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/LineageEdgeDao.java
@@ -76,11 +76,6 @@ public class LineageEdgeDao extends ItemDao<LineageEdge> implements LineageEdgeF
   }
 
   @Override
-  public void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    super.update(idGenerator, itemId, childId, parentIds);
-  }
-
-  @Override
   public List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException {
     LineageEdge lineageEdge  = retrieveFromDatabase(dbSource, sourceKey);
     return super.getLeaves(dbSource, lineageEdge.getId());

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/LineageGraphDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/LineageGraphDao.java
@@ -62,8 +62,8 @@ public class LineageGraphDao extends ItemDao<LineageGraph> implements LineageGra
   }
 
   @Override
-  public void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    super.update(idGenerator, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundException {
+    super.update(itemId, childId, parentIds);
   }
 
   @Override

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/NodeDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/NodeDao.java
@@ -66,11 +66,6 @@ public class NodeDao extends ItemDao<Node> implements NodeFactory {
   }
 
   @Override
-  public void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    super.update(idGenerator, itemId, childId, parentIds);
-  }
-
-  @Override
   public List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException {
     Node node  = retrieveFromDatabase(dbSource, sourceKey);
     return super.getLeaves(dbSource, node.getId());

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/NodeVersionDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/NodeVersionDao.java
@@ -21,7 +21,9 @@ public class NodeVersionDao extends RichVersionDao<NodeVersion> implements NodeV
     final long uniqueId = idGenerator.generateVersionId();
     NodeVersion newNodeVersion = new NodeVersion(uniqueId, nodeVersion.getTags(), nodeVersion.getStructureVersionId(),
       nodeVersion.getReference(), nodeVersion.getParameters(), nodeVersion.getNodeId());
-    new NodeDao().update(idGenerator, nodeVersion.getNodeId(), nodeVersion.getId(), parentIds);
+    //TODO create version successor
+    //TODO pass PostgresClient and VHDD and TagFactory to ItemDao constructor
+    new NodeDao().update(nodeVersion.getNodeId(), nodeVersion.getId(), parentIds);
     //Call super to create 1.version, 2. structure version (need to create a node_id)?, 3. rich version, 4. node_version
     try {
       sqlList.addAll(super.createSqlList(dbSource, newNodeVersion));

--- a/modules/postgres/app/edu/berkeley/ground/postgres/dao/StructureDao.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/dao/StructureDao.java
@@ -55,11 +55,6 @@ public class StructureDao extends ItemDao<Structure> implements StructureFactory
   }
 
   @Override
-  public void update(IdGenerator idGenerator, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    //TODO implement
-  }
-
-  @Override
   public List<Long> getLeaves(Database dbSource, String sourceKey) throws GroundException {
     Structure structure  = retrieveFromDatabase(dbSource, sourceKey);
     return super.getLeaves(dbSource, structure.getId());


### PR DESCRIPTION
removed subclasses of Item calling 'super.update()' and only implemented in Item.update